### PR TITLE
Be able to publish pytruth on PyPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+
+build/
+dist/
+*.egg-info/
+*.egg
+
+bazel*

--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ Provides unittest assertions in a fluent style.
 Translated from the Java implementation,
 [google/truth](https://github.com/google/truth).
 
+### Installing
+
+pytruth can be installed using [pip](https://pypi.org/project/pip/):
+
+```bash
+pip install pytruth
+```
+
 ## License
 
 PyTruth is licensed under the [Apache 2.0 license](LICENSE).
@@ -54,13 +62,13 @@ User group:
 Import the `truth` module and alias the `AssertThat()` method to begin asserting
 things:
 
-```
+```python
 from truth.truth import AssertThat
 ```
 
 Then, instead of writing
 
-```
+```python
 self.assertEqual(a, b)
 self.assertTrue(c)
 self.assertIn(a, d)
@@ -72,7 +80,7 @@ with self.assertRaises(Error):
 
 one would write
 
-```
+```python
 AssertThat(a).IsEqualTo(b)
 AssertThat(c).IsTrue()
 AssertThat(d).Contains(a)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,6 @@
+[bdist_wheel]
+# the code is written to work on both Python 2 and Python 3
+universal=1
+
+[metadata]
+license_file = LICENSE

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,44 @@
+from setuptools import setup, find_packages
+
+INSTALL_REQUIRES = [
+  'wheel',
+  'six',
+]
+
+TESTS_REQUIRES = [
+  'absl-py',
+  "mock; python_version<'3.0'"
+]
+
+setup(name='pytruth',
+      version='1.0.0',
+      description='Provides unittest assertions in a fluent style.',
+      long_description=open('README.md').read(),
+      long_description_content_type='text/markdown',
+      url='https://github.com/google/pytruth',
+      project_urls={
+        'Bug Reports': 'https://groups.google.com/d/forum/pytruth-users',
+        'Source': 'https://github.com/google/pytruth',
+      },
+      author='Gregory Kwok',
+      author_email='gkwok@google.com',
+      packages=find_packages(),
+      license='Apache 2.0',
+      install_requires=INSTALL_REQUIRES,
+      tests_require=TESTS_REQUIRES,
+      classifiers=[
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
+        'License :: OSI Approved :: Apache Software License',
+        'Operating System :: OS Independent',
+        'Intended Audience :: Developers',
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Topic :: Software Development :: Quality Assurance',
+        'Topic :: Software Development :: Testing',
+      ])

--- a/truth/convert_test.py
+++ b/truth/convert_test.py
@@ -22,22 +22,25 @@ import hashlib
 import os
 import tempfile
 
-import convert
-os.environ.setdefault('PBR_VERSION', '1.10.0')
-from mock import mock
+import six
 from absl.testing import absltest
+
+import convert
 import truth
 
+if six.PY2:
+  from unittest import mock
+else:
+  from mock import mock
 
+os.environ.setdefault('PBR_VERSION', '1.10.0')
 
 AssertThat = truth.AssertThat
 
 
 class ConvertTest(absltest.TestCase):
-
   INPUT_PY = 'input.py'
-  TRUTH_DIR = os.path.join(
-      os.environ['TEST_SRCDIR'], os.environ['TEST_WORKSPACE'], 'truth')
+  TRUTH_DIR = os.path.dirname(os.path.abspath(__file__))
   TESTDATA = os.path.join(TRUTH_DIR, 'testdata')
 
   @classmethod
@@ -47,7 +50,7 @@ class ConvertTest(absltest.TestCase):
 
   def setUp(self):
     super(ConvertTest, self).setUp()
-    self.temp_file = tempfile.NamedTemporaryFile(
+    self.temp_file = tempfile.NamedTemporaryFile(mode='w',
         prefix='truth-', suffix='.py', delete=False)
 
   def tearDown(self):

--- a/truth/truth.py
+++ b/truth/truth.py
@@ -132,7 +132,11 @@ import os
 import re
 import threading
 
-from mock import mock
+try:
+  from unittest import mock
+except ImportError:
+  from mock import mock
+
 import six
 from six.moves import zip
 

--- a/truth/truth_test.py
+++ b/truth/truth_test.py
@@ -26,14 +26,18 @@ import os
 import re
 import time
 
-os.environ.setdefault('PBR_VERSION', '5.1.3')
-from mock import mock
-from absl.testing import absltest
-
 import six
+from absl.testing import absltest
 from six.moves import range
+
 import truth
 
+if six.PY2:
+  from mock import mock
+else:
+  from unittest import mock
+
+os.environ.setdefault('PBR_VERSION', '5.1.3')
 
 TYPE_WORD = 'type' if six.PY2 else 'class'
 

--- a/upload_release.sh
+++ b/upload_release.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+[[ -d "dist/" ]] && rm -r dist/
+
+python setup.py sdist bdist_wheel
+
+# https://pypi.org/project/twine/
+twine upload dist/*


### PR DESCRIPTION
The preview of what will be the final result can be viewed on TestPyPI here: https://test.pypi.org/project/pytruth/ (I've published the project using `upload_release.sh` script).

I'm waiting for a validation before we can publish it on the real PyPI 😉 

Changes in source code are mostly some compatibility fixes between Python 2 and 3.