### PR TITLE
Fix typo in NoneSubjectTest.testInvalidOperation

### DIFF
--- a/truth/truth_test.py
+++ b/truth/truth_test.py
@@ -2225,7 +2225,7 @@ class NoneSubjectTest(BaseTest):
         'ContainsAnyIn': ((None,),),
         'ContainsAnyOf': (None,),
         'ContainsExactlyElementsIn': ((None,),),
-        'ContainsNone': ((5,),),
+        'ContainsNoneIn': ((5,),),
         'ContainsNoneOf': (5,),
         'IsOrdered': (),
         'IsOrderedAccordingTo': (truth.Cmp,),


### PR DESCRIPTION
No subject class possess a `ContainsNone` method.
Test passed before because it expects a "no such method" error.